### PR TITLE
Escaped $ and dry-principle on shell scripts in VeraCrypt guide

### DIFF
--- a/how-to-backup-and-encrypt-data-using-rsync-and-veracrypt-on-macos/README.md
+++ b/how-to-backup-and-encrypt-data-using-rsync-and-veracrypt-on-macos/README.md
@@ -230,7 +230,7 @@ if [ "\$(find "\$mount_point/Versioning" -type f -ctime +90)" != "" ]; then
   fi
 fi
 
-open /Volumes/Backup
+open "\$mount_point"
 
 printf "Inspect backup and press enter"
 
@@ -304,7 +304,7 @@ trap dismount ERR INT
 volume_path="$BACKUP_VOLUME_PATH"
 mount_point="/Volumes/Backup"
 
-veracrypt --text --mount --mount-options "readonly" --pim "0" --keyfiles "" --protect-hidden "no" "$volume_path" "$mount_point"
+veracrypt --text --mount --mount-options "readonly" --pim "0" --keyfiles "" --protect-hidden "no" "\$volume_path" "\$mount_point"
 
 open "\$mount_point"
 


### PR DESCRIPTION
Bugfix restore.sh, that it mount correctly. Added missing escape characters.
Optimized backup.sh, use $mount_point instead of hardcoded path to open the backuped data in finder