### PR TITLE
Additional privacy related Firefox tweaks 

### DIFF
--- a/how-to-mitigate-fingerprinting-and-ip-leaks-using-firefox-advanced-preferences/README.md
+++ b/how-to-mitigate-fingerprinting-and-ip-leaks-using-firefox-advanced-preferences/README.md
@@ -23,6 +23,9 @@ Listed: true
 ### Step 4: open `about:config` and set the following
 
 ```
+beacon.enabled = false
+browser.send_pings = false
+dom.battery.enabled = false
 dom.event.clipboardevents.enabled = false
 geo.enabled = false
 media.eme.enabled = false


### PR DESCRIPTION
Hi! 👋 
I don't know if this is acceptable that the video and reference materials would differ, but I'd recommend adding some additional Firefox tweaks to the list:
- beacon.enabled = false [This method is intended for analytics and diagnostics code to send data to a server.](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon)
- browser.send_pings = false [The attribute would be useful for letting websites track visitors' clicks.](https://wiki.mozilla.org/Privacy/Privacy_Task_Force/firefox_about_config_privacy_tweeks)
- dom.battery.enabled = false `Website owners can track the battery status of your device`