### PR TITLE
Removed redundant "-p"

### DIFF
--- a/how-to-configure-hardened-raspberry-pi/README.md
+++ b/how-to-configure-hardened-raspberry-pi/README.md
@@ -32,7 +32,7 @@ When asked for file in which to save key, enter `pi`.
 When asked for passphrase, use output from `openssl rand -base64 24` (and store passphrase in password manager).
 
 ```console
-$ mkdir -p ~/.ssh
+$ mkdir ~/.ssh
 
 $ cd ~/.ssh
 
@@ -173,7 +173,7 @@ ssh pi@10.0.1.248
 #### Create `.ssh` folder
 
 ```shell
-mkdir -p ~/.ssh
+mkdir ~/.ssh
 ```
 
 #### Create `~/.ssh/authorized_keys` using heredoc generated at [step 2](#step-2-generate-heredoc-the-output-of-following-command-will-be-used-at-step-10)

--- a/how-to-self-host-hardened-strongswan-ikev2-ipsec-vpn-server-for-ios-and-macos/README.md
+++ b/how-to-self-host-hardened-strongswan-ikev2-ipsec-vpn-server-for-ios-and-macos/README.md
@@ -36,7 +36,7 @@ When asked for passphrase, use output from `openssl rand -base64 24` (and store 
 Use `vpn-server.pub` public key when setting up server.
 
 ```console
-$ mkdir -p ~/.ssh
+$ mkdir ~/.ssh
 
 $ cd ~/.ssh
 


### PR DESCRIPTION
`$HOME` should already exist, thus `mkdir -p` shouldn't be necessary, `mkdir` should suffice.