### PR TITLE
added missing quotation marks to first EOF

### DIFF
--- a/how-to-backup-and-encrypt-data-using-rsync-and-veracrypt-on-macos/README.md
+++ b/how-to-backup-and-encrypt-data-using-rsync-and-veracrypt-on-macos/README.md
@@ -261,7 +261,7 @@ veracrypt --text --dismount "$BACKUP_VOLUME_PATH"
 ### Step 12: create `/usr/local/bin/backup.sh` script
 
 ```shell
-cat << EOF > /usr/local/bin/backup.sh
+cat << "EOF" > /usr/local/bin/backup.sh
 #! /bin/sh
 
 set -e
@@ -340,7 +340,7 @@ Press <kbd>i</kbd> to enter insert mode, edit backup script, press <kbd>esc</kbd
 ### Step 14: create `/usr/local/bin/check.sh` script
 
 ```shell
-cat << EOF > /usr/local/bin/check.sh
+cat << "EOF" > /usr/local/bin/check.sh
 #! /bin/sh
 
 set -e
@@ -368,7 +368,7 @@ chmod +x /usr/local/bin/check.sh
 ### Step 15: create `/usr/local/bin/restore.sh` script
 
 ```shell
-cat << EOF > /usr/local/bin/restore.sh
+cat << "EOF" > /usr/local/bin/restore.sh
 #! /bin/sh
 
 set -e

--- a/how-to-configure-borg-client-on-macos-using-command-line/README.md
+++ b/how-to-configure-borg-client-on-macos-using-command-line/README.md
@@ -131,7 +131,7 @@ BORG_HOSTNAME="ch-s011.rsync.net"
 #### Generate `authorized_keys` file
 
 ```shell
-cat << EOF > ~/Desktop/authorized_keys
+cat << "EOF" > ~/Desktop/authorized_keys
 command="borg1 serve --restrict-to-repository /data1/home/$BORG_USERNAME/backup --storage-quota $BORG_STORAGE_QUOTA",restrict $(cat ~/.ssh/borg.pub)
 command="borg1 serve --append-only --restrict-to-repository /data1/home/$BORG_USERNAME/backup --storage-quota $BORG_STORAGE_QUOTA",restrict $(cat ~/.ssh/borg-append-only.pub)
 EOF
@@ -217,7 +217,7 @@ BACKUP_NAME="$USER-macbook-pro"
 ### Step 10: create `/usr/local/bin/borg-backup.sh` script
 
 ```shell
-cat << EOF > /usr/local/bin/borg-backup.sh
+cat << "EOF" > /usr/local/bin/borg-backup.sh
 #! /bin/sh
 
 set -e
@@ -251,7 +251,7 @@ vi /usr/local/bin/borg-backup.sh
 ### Step 12: create `/usr/local/bin/borg-list.sh` script
 
 ```shell
-cat << EOF > /usr/local/bin/borg-list.sh
+cat << "EOF" > /usr/local/bin/borg-list.sh
 #! /bin/sh
 
 set -e
@@ -272,7 +272,7 @@ chmod +x /usr/local/bin/borg-list.sh
 ### Step 13: create `/usr/local/bin/borg-check.sh` script
 
 ```shell
-cat << EOF > /usr/local/bin/borg-check.sh
+cat << "EOF" > /usr/local/bin/borg-check.sh
 #! /bin/sh
 
 set -e
@@ -293,7 +293,7 @@ chmod +x /usr/local/bin/borg-check.sh
 ### Step 14: create `/usr/local/bin/borg-restore.sh` script
 
 ```shell
-cat << EOF > /usr/local/bin/borg-restore.sh
+cat << "EOF" > /usr/local/bin/borg-restore.sh
 #! /bin/sh
 
 set -e
@@ -334,7 +334,7 @@ chmod +x /usr/local/bin/borg-restore.sh
 ### Step 15: create `/usr/local/bin/borg-prune.sh` script
 
 ```shell
-cat << EOF > /usr/local/bin/borg-prune.sh
+cat << "EOF" > /usr/local/bin/borg-prune.sh
 #! /bin/sh
 
 set -e

--- a/how-to-configure-hardened-raspberry-pi/README.md
+++ b/how-to-configure-hardened-raspberry-pi/README.md
@@ -65,7 +65,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDCzQpX9uqDP8L2gSZNJxYEi04Y1pZWz28v4zANY5dU
 ### Step 2: generate heredoc (the output of following command will be used at [step 10](#step-10-configure-pi-ssh-authorized-keys))
 
 ```shell
-cat << EOF
+cat << "EOF"
 cat << "_EOF" > ~/.ssh/authorized_keys
 $(cat ~/.ssh/pi.pub)
 _EOF

--- a/how-to-configure-self-hosted-vpn-kill-switch-using-pf-firewall-on-macos/README.md
+++ b/how-to-configure-self-hosted-vpn-kill-switch-using-pf-firewall-on-macos/README.md
@@ -173,7 +173,7 @@ KILLSWITCH_VPN_ENDPOINT_IPS="{ 185.193.126.203 }"
 This anchor blocks everything except DHCP and VPN requests.
 
 ```shell
-cat << EOF | sudo tee /etc/pf.anchors/local.pf.strict
+cat << "EOF" | sudo tee /etc/pf.anchors/local.pf.strict
 # Options
 set block-policy drop
 set ruleset-optimization basic
@@ -204,7 +204,7 @@ sudo chmod 644 /etc/pf.anchors/local.pf.strict
 Same as strict but allows multicast DNS and local network requests.
 
 ```shell
-cat << EOF | sudo tee /etc/pf.anchors/local.pf.trusted
+cat << "EOF" | sudo tee /etc/pf.anchors/local.pf.trusted
 # Options
 set block-policy drop
 set ruleset-optimization basic

--- a/how-to-configure-strongswan-client-on-headless-debian-based-linux-computer/README.md
+++ b/how-to-configure-strongswan-client-on-headless-debian-based-linux-computer/README.md
@@ -42,7 +42,7 @@ STRONGSWAN_CLIENT_NAME=bob
 #### Update OpenSSL config file
 
 ```shell
-cat << EOF > openssl.cnf
+cat << "EOF" > openssl.cnf
 [ req ]
 distinguished_name = req_distinguished_name
 attributes = req_attributes
@@ -161,7 +161,7 @@ STRONGSWAN_SERVER_IP=185.193.126.203
 
 ```shell
 cp /etc/ipsec.conf /etc/ipsec.conf.backup
-cat << EOF > /etc/ipsec.conf
+cat << "EOF" > /etc/ipsec.conf
 conn ikev2
   auto=start
   ike=aes256gcm16-prfsha512-ecp384!
@@ -184,7 +184,7 @@ EOF
 
 ```shell
 cp /etc/ipsec.secrets /etc/ipsec.secrets.backup
-cat << EOF > /etc/ipsec.secrets
+cat << "EOF" > /etc/ipsec.secrets
 : RSA $STRONGSWAN_CLIENT_NAME.key
 EOF
 ```
@@ -217,7 +217,7 @@ On client computer: run `chmod -R 600 /etc/ipsec.d/private` -->
 On certificate authority computer, run:
 
 ```shell
-cat << EOF
+cat << "EOF"
 cat << "_EOF" > /etc/ipsec.d/cacerts/ca.crt
 $(cat ca.crt)
 _EOF
@@ -265,7 +265,7 @@ _EOF
 On certificate authority computer, run:
 
 ```shell
-cat << EOF
+cat << "EOF"
 cat << "_EOF" > /etc/ipsec.d/private/$STRONGSWAN_CLIENT_NAME.key
 $(cat $STRONGSWAN_CLIENT_NAME.key)
 _EOF
@@ -333,7 +333,7 @@ _EOF
 On certificate authority computer, run:
 
 ```shell
-cat << EOF
+cat << "EOF"
 cat << "_EOF" > /etc/ipsec.d/certs/$STRONGSWAN_CLIENT_NAME.crt
 $(cat $STRONGSWAN_CLIENT_NAME.crt)
 _EOF

--- a/how-to-self-host-hardened-borg-server/README.md
+++ b/how-to-self-host-hardened-borg-server/README.md
@@ -105,7 +105,7 @@ BORG_STORAGE_QUOTA="10G"
 #### Generate heredoc (the output of following command will be used at [step 8](#create-homeborgsshauthorized_keys-using-heredoc-generated-at-step-2))
 
 ```shell
-cat << EOF
+cat << "EOF"
 cat << "_EOF" > /home/borg/.ssh/authorized_keys
 command="borg serve --restrict-to-repository /home/borg/backup --storage-quota $BORG_STORAGE_QUOTA",restrict $(cat ~/.ssh/borg.pub)
 command="borg serve --append-only --restrict-to-repository /home/borg/backup --storage-quota $BORG_STORAGE_QUOTA",restrict $(cat ~/.ssh/borg-append-only.pub)

--- a/how-to-self-host-hardened-strongswan-ikev2-ipsec-vpn-server-for-ios-and-macos/README.md
+++ b/how-to-self-host-hardened-strongswan-ikev2-ipsec-vpn-server-for-ios-and-macos/README.md
@@ -482,7 +482,7 @@ cp /etc/ipsec.conf /etc/ipsec.conf.backup
 If network is IPv4-only, run:
 
 ```shell
-cat << EOF > /etc/ipsec.conf
+cat << "EOF" > /etc/ipsec.conf
 config setup
   charondebug="ike 1, knl 1, cfg 1"
 
@@ -516,7 +516,7 @@ EOF
 If network is dual stack (IPv4 + IPv6) run:
 
 ```shell
-cat << EOF > /etc/ipsec.conf
+cat << "EOF" > /etc/ipsec.conf
 config setup
   charondebug="ike 1, knl 1, cfg 1"
 
@@ -630,7 +630,7 @@ STRONGSWAN_CLIENT_NAME=alice
 #### Create OpenSSL config file
 
 ```shell
-cat << EOF > openssl.cnf
+cat << "EOF" > openssl.cnf
 [ req ]
 distinguished_name = req_distinguished_name
 attributes = req_attributes
@@ -719,7 +719,7 @@ Verifying - Enter Export Password:
 On Mac, run:
 
 ```shell
-cat << EOF
+cat << "EOF"
 cat << "_EOF" > /etc/ipsec.d/cacerts/ca.crt
 $(cat ca.crt)
 _EOF
@@ -767,7 +767,7 @@ _EOF
 On Mac, run:
 
 ```shell
-cat << EOF
+cat << "EOF"
 cat << "_EOF" > /etc/ipsec.d/private/server.key
 $(cat server.key)
 _EOF
@@ -835,7 +835,7 @@ _EOF
 On Mac, run:
 
 ```shell
-cat << EOF
+cat << "EOF"
 cat << "_EOF" > /etc/ipsec.d/certs/server.crt
 $(cat server.crt)
 _EOF


### PR DESCRIPTION
Hi Sun, just noticed some inconsistency with the syntax of `cat << "EOF"`. According to the heads-up the first EOF should be surrounded by quotes.

PS: I might be missing the reason for the lack of quotation marks though…