### PR TITLE
Reorder nftables rules for remote access preservation

### DIFF
--- a/how-to-configure-hardened-debian-server/README.md
+++ b/how-to-configure-hardened-debian-server/README.md
@@ -205,17 +205,19 @@ systemctl start nftables
 ```shell
 nft flush ruleset
 nft add table ip firewall
-nft add chain ip firewall input { type filter hook input priority 0 \; policy drop \; }
+nft add chain ip firewall input { type filter hook input priority 0 \; }
 nft add rule ip firewall input iif lo accept
 nft add rule ip firewall input iif != lo ip daddr 127.0.0.0/8 drop
 nft add rule ip firewall input tcp dport ssh accept
 nft add rule ip firewall input ct state established,related accept
+nft add chain ip firewall input { type filter hook input priority 0 \; policy drop \; }
 nft add chain ip firewall forward { type filter hook forward priority 0 \; policy drop \; }
-nft add chain ip firewall output { type filter hook output priority 0 \; policy drop \; }
+nft add chain ip firewall output { type filter hook output priority 0 \; }
 nft add rule ip firewall output oif lo accept
 nft add rule ip firewall output tcp dport { http, https } accept
 nft add rule ip firewall output udp dport { domain, ntp } accept
 nft add rule ip firewall output ct state established,related accept
+nft add chain ip firewall output { type filter hook output priority 0 \; policy drop \; }
 ```
 
 If network is IPv4-only, run:

--- a/how-to-configure-hardened-raspberry-pi/README.md
+++ b/how-to-configure-hardened-raspberry-pi/README.md
@@ -302,17 +302,19 @@ systemctl start nftables
 ```shell
 nft flush ruleset
 nft add table ip firewall
-nft add chain ip firewall input { type filter hook input priority 0 \; policy drop \; }
+nft add chain ip firewall input { type filter hook input priority 0 \; }
 nft add rule ip firewall input iif lo accept
 nft add rule ip firewall input iif != lo ip daddr 127.0.0.0/8 drop
 nft add rule ip firewall input tcp dport ssh accept
 nft add rule ip firewall input ct state established,related accept
+nft add chain ip firewall input { type filter hook input priority 0 \; policy drop \; }
 nft add chain ip firewall forward { type filter hook forward priority 0 \; policy drop \; }
-nft add chain ip firewall output { type filter hook output priority 0 \; policy drop \; }
+nft add chain ip firewall output { type filter hook output priority 0 \; }
 nft add rule ip firewall output oif lo accept
 nft add rule ip firewall output tcp dport { http, https } accept
 nft add rule ip firewall output udp dport { domain, ntp } accept
 nft add rule ip firewall output ct state established,related accept
+nft add chain ip firewall output { type filter hook output priority 0 \; policy drop \; }
 ```
 
 If network is IPv4-only, run:


### PR DESCRIPTION
This PR reorders the nftables rule commands to ensure essential rules (like SSH access) are established before setting the input and output chains to a default drop policy. This prevents remote access disruption during configuration.