### PR TITLE
Update macFUSE installation on apple silicon macs

### DIFF
--- a/how-to-back-up-and-encrypt-data-using-rsync-and-veracrypt-on-macos/README.md
+++ b/how-to-back-up-and-encrypt-data-using-rsync-and-veracrypt-on-macos/README.md
@@ -172,6 +172,8 @@ Error: mount_macfuse: the file system is not available (1)
 
 ![Allow extension 2](./allow-extension-2.png)
 
+> Heads-up: For users with the latest Apple Silicon Macs, you'll need to reboot your computer into Recovery Mode and use the Security Utility to allow kernel extensions. For detailed instructions, please refer to the [Getting Started guide for macFUSE](https://github.com/macfuse/macfuse/wiki/Getting-Started).
+
 ```console
 $ veracrypt --text --create "$BACKUP_VOLUME_PATH"
 Volume type:

--- a/how-to-configure-borg-client-on-macos-using-command-line/README.md
+++ b/how-to-configure-borg-client-on-macos-using-command-line/README.md
@@ -486,6 +486,8 @@ umount: /var/folders/dl/mbmsd2m51nb8dvhmtz114j8w0000gn/T/borg: not currently mou
 
 ![Allow extension 2](./allow-extension-2.png)
 
+> Heads-up: For users with the latest Apple Silicon Macs, you'll need to reboot your computer into Recovery Mode and use the Security Utility to allow kernel extensions. For detailed instructions, please refer to the [Getting Started guide for macFUSE](https://github.com/macfuse/macfuse/wiki/Getting-Started).
+
 ```console
 $ borg-restore.sh
 Restore data and press enter


### PR DESCRIPTION
This PR updates the installation guide to include specific instructions for enabling macFUSE on Apple Silicon Macs. The current documentation only covers the process for older Mac models, and does not address the additional steps required on the latest Apple Silicon devices.