### PR TITLE
Fixed broken link

### DIFF
--- a/how-to-harden-firefox/README.md
+++ b/how-to-harden-firefox/README.md
@@ -34,7 +34,7 @@ $ curl --fail --remote-name https://raw.githubusercontent.com/arkenfox/user.js/r
 > Heads-up: enables [Mullvad DNS over HTTPS](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/).
 
 ```console
-$ curl --fail --remote-name https://sunknudsen.com/guides/how-to-configure-firefox-for-privacy-and-security/user-overrides.js
+$ curl --fail --remote-name https://sunknudsen.com/guides/how-to-harden-firefox/user-overrides.js
 
 $ cat user-overrides.js >> user.js
 ```


### PR DESCRIPTION
The original link was no longer accessible, preventing the script from being downloaded via curl --fail --remote-name. The new link points to the correct and currently maintained guide.